### PR TITLE
Feature/display data from response

### DIFF
--- a/Sources/app.js
+++ b/Sources/app.js
@@ -75,7 +75,7 @@ function APIRequest(jsonObj) {
         key_state = null;
 
     function restartPeriodicPoll() {
-        const frequency = settings.poll_status_frequency || 15;
+        const frequency = settings.poll_status_frequency || settings.poll_status_data_frequency || 15;
 
         destroy();
 

--- a/Sources/app.js
+++ b/Sources/app.js
@@ -79,7 +79,7 @@ function APIRequest(jsonObj) {
 
         destroy();
 
-        if (settings.advanced_settings && settings.poll_status) {
+        if (settings.advanced_settings && (settings.poll_status || settings.poll_status_data)) {
             sendRequest(do_status_poll = true);
 
             poll_timer = setInterval(function() {
@@ -95,18 +95,22 @@ function APIRequest(jsonObj) {
         }
 
         if (do_status_poll) {
-            if (!Boolean(settings.response_parse) || !Boolean(settings.poll_status)) return;
-            if (!settings.poll_status_url) return;
+            // We check the parent-child relationship between settings to skip early when not needed
+            //    (left-side: parsing for background && right-side: parsing for displaying data)
+            if (!Boolean(settings.response_parse) && !Boolean(settings.response_data)) return;
+            if (!Boolean(settings.poll_status)    && !Boolean(settings.poll_status_data)) return;
+            if (!settings.poll_status_url         && !settings.poll_status_data_url) return;
         }
 
         let url    = settings.request_url;
         let body   = undefined;
         let method = 'GET';
         if (settings.advanced_settings) {
-            if (do_status_poll) url = settings.poll_status_url;
+            if (do_status_poll) url = settings.poll_status_url ?? settings.poll_status_data_url;
             if (settings.request_parameters) {
-                body   = settings.request_body;
-                method = (do_status_poll ? settings.poll_status_method : settings.request_method) ?? method;
+                body        = settings.request_body;
+                poll_method = settings.poll_status_method ?? settings.poll_status_data_method;
+                method      = (do_status_poll ? poll_method : settings.request_method) ?? method;
             }
         }
 

--- a/Sources/propertyinspector/index.html
+++ b/Sources/propertyinspector/index.html
@@ -124,8 +124,8 @@
                     <div style="width: 15px;"></div>
                     <div class="sdpi-item-value">
                         <div class="sdpi-item-child">
-                            <input id="poll_status"  type="checkbox">
-                            <label for="poll_status" class="sdpi-item-label"><span></span>Periodically poll a URL for status</label>
+                            <input id="poll_status_data"  type="checkbox">
+                            <label for="poll_status_data" class="sdpi-item-label"><span></span>Periodically poll a URL for status</label>
                         </div>
                     </div>
                 </div>

--- a/Sources/propertyinspector/index.html
+++ b/Sources/propertyinspector/index.html
@@ -120,6 +120,55 @@
                     <div class="sdpi-item-label">Unit</div>
                     <input class="sdpi-item-value" type="text" id="response_data_unit">
                 </div>
+                <div class="sdpi-item">
+                    <div style="width: 15px;"></div>
+                    <div class="sdpi-item-value">
+                        <div class="sdpi-item-child">
+                            <input id="poll_status"  type="checkbox">
+                            <label for="poll_status" class="sdpi-item-label"><span></span>Periodically poll a URL for status</label>
+                        </div>
+                    </div>
+                </div>
+                <div id="poll_status_data_container" style="display:none">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Status URL</div>
+                        <input class="sdpi-item-value" type="text" id="poll_status_data_url">
+                    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">HTTP Method</div>
+                        <select class="sdpi-item-value select" id="poll_status_data_method">
+                            <option value="GET" selected>GET</option>
+                            <option value="POST">POST</option>
+                            <option value="HEAD">HEAD</option>
+                            <option value="PUT">PUT</option>
+                            <option value="PATCH">PATCH</option>
+                            <option value="DELETE">DELETE</option>
+                        </select>
+                    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Poll Frequency</div>
+                        <input class="sdpi-item-value max10" type="text" id="poll_status_data_frequency" pattern="\d+" value="15"> seconds
+                    </div>
+                    <div class="sdpi-item">
+                        <div style="width: 15px;"></div>
+                        <div class="sdpi-item-value">
+                            <div class="sdpi-item-child">
+                                <input id="poll_status_parse" type="checkbox">
+                                <label for="poll_status_data_parse" class="sdpi-item-label"><span></span>Parse a different field and value from response</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="poll_status_data_parse_container" style="display:none">
+                        <div class="sdpi-item">
+                            <div class="sdpi-item-label">JSON Path</div>
+                            <input class="sdpi-item-value" type="text" id="poll_status_data_parse_field">
+                        </div>
+                        <div class="sdpi-item">
+                            <div class="sdpi-item-label">Expected Value</div>
+                            <input class="sdpi-item-value" type="text" id="poll_status_data_parse_value">
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="sdpi-item">

--- a/Sources/propertyinspector/index.html
+++ b/Sources/propertyinspector/index.html
@@ -85,6 +85,47 @@
                 <div style="width: 15px;"></div>
                 <div class="sdpi-item-value">
                     <div class="sdpi-item-child">
+                        <input id="response_data" type="checkbox">
+                        <label for="response_data" class="sdpi-item-label"><span></span>Button shows data from response</label>
+                    </div>
+                </div>
+            </div>
+            <div id="response_data_container" style="display:none">
+                <details>
+                    <summary>Expand for Response data display instructions</summary>
+                    <p>Specify the JSON path in the API response whose value will show up on the key.</p>
+                    <p>A missing path will only display question marks.</p>
+                    <p>YOU MUST NOT USE THE TITLE OTHERWISE IT WILL HIDE THE DATA RETURNED</p>
+                    <p>(but you can use the title color and size config to adjust the data displayed).</p>
+                    <p>If you want to make the data nicer, you can use the extra fields 'Name' and 'Unit'</p>
+                    <p>to put text before and after the data from the response.</p>
+                </details>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">JSON Path</div>
+                    <input class="sdpi-item-value" type="text" id="response_data_field">
+                </div>
+                <div class="sdpi-item">Background</div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-group file" id="matchedfilepickergroup">
+                        <input class="sdpi-item-value" type="file" id="background_image" accept=".jpg, .jpeg, .png, .ico, .gif, .bmp, .tiff">
+                        <label class="sdpi-file-info " for="background_image">No file...</label>
+                        <label class="sdpi-file-label" for="background_image">Choose file...</label>
+                    </div>
+                </div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Name</div>
+                    <input class="sdpi-item-value" type="text" id="response_data_name">
+                </div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Unit</div>
+                    <input class="sdpi-item-value" type="text" id="response_data_unit">
+                </div>
+            </div>
+
+            <div class="sdpi-item">
+                <div style="width: 15px;"></div>
+                <div class="sdpi-item-value">
+                    <div class="sdpi-item-child">
                         <input id="response_parse" type="checkbox">
                         <label for="response_parse" class="sdpi-item-label"><span></span>Set button image based on response</label>
                     </div>

--- a/Sources/propertyinspector/index_pi.js
+++ b/Sources/propertyinspector/index_pi.js
@@ -342,6 +342,9 @@ function showHideSettings() {
     d = document.getElementById('request_parameters_container');
     d.style.display = settings.request_parameters ? "" : "none";
 
+    d = document.getElementById('response_data_container');
+    d.style.display = settings.response_data ? "" : "none";
+
     d = document.getElementById('response_parse_container');
     d.style.display = settings.response_parse ? "" : "none";
 

--- a/Sources/propertyinspector/index_pi.js
+++ b/Sources/propertyinspector/index_pi.js
@@ -351,8 +351,14 @@ function showHideSettings() {
     d = document.getElementById('poll_status_container');
     d.style.display = settings.poll_status ? "" : "none";
 
+    d = document.getElementById('poll_status_data_container');
+    d.style.display = settings.poll_status_data ? "" : "none";
+
     d = document.getElementById('poll_status_parse_container');
     d.style.display = settings.poll_status_parse ? "" : "none";
+
+    d = document.getElementById('poll_status_data_parse_container');
+    d.style.display = settings.poll_status_data_parse ? "" : "none";
 }
 
 function localize(s) {


### PR DESCRIPTION
Hi,

as discussed in issue #3, here is a possible implementation of the display of data from the response on the button (latest stable on the right and this PR's code with the same API call on the left):
<img width="179" alt="AFTER-and-BEFORE" src="https://user-images.githubusercontent.com/48991072/164986519-6187f89a-f995-410d-9bde-8c0f01774d9a.png">

This implementation uses the setTitle() to display the data on the button. The good: the user can leverage the title config (color, location, font size...) from the config to control the look of the text. The bad: you cannot use the Title field (otherwise it will hide the data from setTitle()) and must use the name field instead.

I will give a look at an alternative implementation where the data from the response is rendered as bitmap instead (but not quite sure how good it will look and it will come with its limitations on text style if we want to keep the config reasonably compact).