### PR TITLE
Adds SVG Icon Support & Updates Manifest for Compatibility

### DIFF
--- a/Sources/manifest.json
+++ b/Sources/manifest.json
@@ -1,31 +1,40 @@
 {
-    "Actions": [
-        {
-            "Icon": "images/api_action",
-            "Name": "API Request",
-            "States": [
-                { "Image": "images/api_key" }
-            ],
-            "Tooltip": "Make an API Request",
-            "UUID": "com.github.mjbnz.sd-api-request"
-        }
-    ],
-    "SDKVersion": 2,
-    "Author": "mjbnz",
-    "CodePath": "index.html",
-    "PropertyInspectorPath": "propertyinspector/index.html",
-    "Description": "REST Easily",
-    "Name": "API Request",
-    "Icon": "images/api_action",
-    "Category": "API Request",
-    "CategoryIcon": "images/api_action",  
-    "URL": "https://github.com/mjbnz/sd-api-request/",
-    "Version": "0.2",
-    "OS": [
-        { "Platform": "mac",     "MinimumVersion": "10.11" },
-        { "Platform": "windows", "MinimumVersion": "10"    }
-    ],
-    "Software": {
-        "MinimumVersion": "4.1"
-    }
+	"Actions": [
+		{
+			"Icon": "images/api_action",
+			"Name": "API Request",
+			"States": [
+				{
+					"Image": "images/api_key"
+				}
+			],
+			"Tooltip": "Make an API Request",
+			"UUID": "com.github.mjbnz.sd-api-request"
+		}
+	],
+	"SDKVersion": 2,
+	"Author": "mjbnz",
+	"CodePath": "index.html",
+	"PropertyInspectorPath": "propertyinspector/index.html",
+	"Description": "REST Easily",
+	"Name": "API Request",
+	"Icon": "images/api_action",
+	"Category": "API Request",
+	"CategoryIcon": "images/api_action",
+	"URL": "https://github.com/mjbnz/sd-api-request/",
+	"Version": "0.2.0.0",
+	"OS": [
+		{
+			"Platform": "mac",
+			"MinimumVersion": "10.11"
+		},
+		{
+			"Platform": "windows",
+			"MinimumVersion": "10"
+		}
+	],
+	"Software": {
+		"MinimumVersion": "6.8"
+	},
+	"UUID": "com.github.mjbnz.sd-api-request"
 }

--- a/Sources/propertyinspector/index.html
+++ b/Sources/propertyinspector/index.html
@@ -109,7 +109,7 @@
                 <div class="sdpi-item">
                     <div class="sdpi-item-label">..matched</div>
                     <div class="sdpi-item-group file" id="matchedfilepickergroup">
-                        <input class="sdpi-item-value" type="file" id="image_matched" accept=".jpg, .jpeg, .png, .ico, .gif, .bmp, .tiff">
+                        <input class="sdpi-item-value" type="file" id="image_matched" accept=".jpg, .jpeg, .png, .ico, .gif, .bmp, .tiff, .svg">
                         <label class="sdpi-file-info " for="image_matched">No file...</label>
                         <label class="sdpi-file-label" for="image_matched">Choose file...</label>
                     </div>
@@ -117,7 +117,7 @@
                 <div class="sdpi-item">
                     <div class="sdpi-item-label">..unmatched</div>
                     <div class="sdpi-item-group file" id="unmatchedfilepickergroup">
-                        <input class="sdpi-item-value" type="file" id="image_unmatched" accept=".jpg, .jpeg, .png, .ico, .gif, .bmp, .tiff">
+                        <input class="sdpi-item-value" type="file" id="image_unmatched" accept=".jpg, .jpeg, .png, .ico, .gif, .bmp, .tiff, .svg">
                         <label class="sdpi-file-info " for="image_unmatched">No file...</label>
                         <label class="sdpi-file-label" for="image_unmatched">Choose file...</label>
                     </div>


### PR DESCRIPTION
This PR adds support for SVG icons in the property inspector for better consistency with modern Stream Deck icon packs. Additionally, the manifest.json has been updated to comply with the latest version of the Stream Deck npm package, ensuring compatibility with recent builds.

Tested successfully with no issues. Let me know if you have any questions!